### PR TITLE
fix matching boolean attribute with empty value

### DIFF
--- a/src/utils/HtmlAttributesToReact.js
+++ b/src/utils/HtmlAttributesToReact.js
@@ -12,7 +12,8 @@ const getParsedAttributeValue = function(attribute, value) {
 
   // if the attribute if a boolean then it's value should be the same as it's name
   // e.g. disabled="disabled"
-  if (BooleanAttributes.indexOf(attribute) >= 0) {
+  let lowerBooleanAttributes = BooleanAttributes.map(attr => attr.toLowerCase());
+  if (lowerBooleanAttributes.indexOf(attribute.toLowerCase()) >= 0) {
     value = attribute;
   }
 

--- a/test/unit/utils/HtmlAttributesToReact.spec.js
+++ b/test/unit/utils/HtmlAttributesToReact.spec.js
@@ -22,7 +22,8 @@ describe('Testing `utils/HtmlAttributesToReact`', () => {
       'UPPER-CASE-TEST-ATTRIBUTE': 'upperTestAttribute',
       // boolean attributes
       disabled: '',
-      checked: ''
+      checked: '',
+      autoplay: ''
     };
 
     const expectedReactAttributes = {
@@ -30,14 +31,15 @@ describe('Testing `utils/HtmlAttributesToReact`', () => {
       htmlFor: 'testFor',
       minLength: 1,
       acceptCharset: 'testAcceptCharset',
-      formNoValidate: 'testFormNoValidate',
+      formNoValidate: 'formNoValidate',
       label: 'testLabel',
       'data-test': 'test',
       'aria-role': 'role',
       testattribute: 'testAttribute',
       'upper-case-test-attribute': 'upperTestAttribute',
       disabled: 'disabled',
-      checked: 'checked'
+      checked: 'checked',
+      autoPlay: 'autoPlay'
     };
 
     expect(HtmlAttributesToReact(htmlAttributes)).toEqual(expectedReactAttributes);


### PR DESCRIPTION
If you use any boolean attribute contains upper-case char with empty value, it doesn't work correctly.

For example ...

### Source HTML

```
<video autoPlay>...</video>
```

### Result

```
<video>...</video>
```

### Expected Result

```
<video autoPlay="autoPlay">...</video>
```
