### PR TITLE
Decode entities in text nodes

### DIFF
--- a/src/HtmlParser.js
+++ b/src/HtmlParser.js
@@ -8,6 +8,6 @@ import ProcessNodes from './utils/ProcessNodes';
  * @returns {Array} List of top level React elements
  */
 export default function HtmlParser(html) {
-  const nodes = htmlparser2.parseDOM(html);
+  const nodes = htmlparser2.parseDOM(html, {decodeEntities: true});
   return ProcessNodes(nodes);
 }


### PR DESCRIPTION
This ensures `<p>foo&nbsp;bar</p>` is decoded to "foo bar"

Fixes #12