### PR TITLE
Fix empty inline style attribute bug from breaking React renders

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,7 +15,8 @@ module.exports = function(karma) {
     singleRun: false,
     frameworks: [
       'jasmine',
-      'phantomjs-shim'
+      'phantomjs-shim',
+      'es6-shim'
     ],
     preprocessors: {
       'tests.webpack.js': 'webpack'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1826,6 +1826,12 @@
         "es6-symbol": "3.1.1"
       }
     },
+    "es5-shim": {
+      "version": "4.5.9",
+      "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.5.9.tgz",
+      "integrity": "sha1-Kh4rnlg/9f7Qwgo+4svz91IwpcA=",
+      "dev": true
+    },
     "es6-iterator": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
@@ -1869,6 +1875,12 @@
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
       }
+    },
+    "es6-shim": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/es6-shim/-/es6-shim-0.35.3.tgz",
+      "integrity": "sha1-m/tzY/7//4emzbbNk+QF7DxLbyY=",
+      "dev": true
     },
     "es6-symbol": {
       "version": "3.1.1",
@@ -4153,6 +4165,16 @@
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
+      }
+    },
+    "karma-es6-shim": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/karma-es6-shim/-/karma-es6-shim-1.0.0.tgz",
+      "integrity": "sha1-qutTCGK895NA69WI9PnlfehCtHk=",
+      "dev": true,
+      "requires": {
+        "es5-shim": "4.5.9",
+        "es6-shim": "0.35.3"
       }
     },
     "karma-jasmine": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "json-loader": "^0.5.4",
     "karma": "^0.13.22",
     "karma-coverage": "^1.0.0",
+    "karma-es6-shim": "^1.0.0",
     "karma-jasmine": "^1.0.2",
     "karma-phantomjs-launcher": "^1.0.0",
     "karma-phantomjs-shim": "^1.4.0",

--- a/src/utils/generatePropsFromAttributes.js
+++ b/src/utils/generatePropsFromAttributes.js
@@ -12,9 +12,12 @@ export default function generatePropsFromAttributes(attributes, key) {
   // generate props
   const props = Object.assign({}, htmlAttributesToReact(attributes), { key });
 
-  // if there is a style prop then convert it to a React style object
-  if (props.style) {
+  // if there is an inline/string style prop then convert it to a React style object
+  // otherwise, it is invalid and omitted
+  if (typeof props.style === 'string' || props.style instanceof String) {
     props.style = inlineStyleToObject(props.style);
+  } else {
+    delete props.style;
   }
 
   return props;

--- a/test/integration/integration.spec.js
+++ b/test/integration/integration.spec.js
@@ -68,6 +68,10 @@ describe('Integration tests: ', () => {
     test(`<div style="border-radius:1px;background:red${trailingSemiComma}">test</div>`);
   });
 
+  it('should ignore inline styles that are empty strings', () => {
+    test('<div style="">test</div>', '<div>test</div>');
+  });
+
   it('should not allow nesting of void elements', () => {
     test('<img><p>test</p></img>', '<img/><p>test</p>');
   });

--- a/test/unit/utils/generatePropsFromAttributes.spec.js
+++ b/test/unit/utils/generatePropsFromAttributes.spec.js
@@ -45,4 +45,16 @@ describe('Testing `utils/generatePropsFromAttributes`', () => {
 
   });
 
+  it('should return an object containing the converted style prop when the style html attribute is an empty string', () => {
+    const attributes = {
+      style: ''
+    };
+
+    expect(generatePropsFromAttributes(attributes, 'style-key')).toEqual({
+      style: 'converted-style',
+      key: 'style-key'
+    });
+    expect(inlineStyleToObject).toHaveBeenCalledWith('');
+  });
+
 });


### PR DESCRIPTION
Summary:
-----------
Render html tags that have inline styles of empty string `""` will cause React to raise an error.
```
Uncaught Error: The `style` prop expects a mapping from style properties to values, not a string. For example, style={{marginRight: spacing + 'em'}} when using JSX. This DOM node was rendered by `Comment`.
```
![image](https://user-images.githubusercontent.com/7256178/33396099-66ea254c-d4fc-11e7-85d0-3d879bd724d0.png)

The html that caused this error was written like so:
```
<p style="">
....
</p>
```

The reason why this causes an error is because `generatePropsFromAttributes` only calls `inlineStyleToObject` on `props.style` when it is **truthy** - which in JS *does not* include `""`.

While people don't usually add empty strings as inline styles, this HTML is technically still correct and should be supported.

Changes proposed:
-------------------

To fix this, we can simply check that the type of `props.style` is a string, and run `inlineStyleToObject` on it only when that check passes. 
It's ok for empty strings to be passed to `inlineStyleToObject` because it already takes care of this case.
I also added an `else` clause to delete `props.style`, since I assume that if the style somehow became something other than a string, it should be invalid.

cc: @wrakky 