### PR TITLE
Clarify that the `data` property is included for comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The transform function will be called for every node that is parsed by the libra
   - `next` (node): The node's next sibling
   - `prev` (node): The node's previous sibling
   - `parent` (node): The node's parent
-  - `data` (string): The text content, if the `type` is text
+  - `data` (string): The text content, if the `type` is `text` or `comment`
 - `index` (number): The index of the node in relation to it's parent
 
 #### Return Types


### PR DESCRIPTION
I've noticed this property is filled in for comments as well, so I wanted to update the README to take that into account.