### PR TITLE
Changed Object.assign's order to allow user provided keys to be used

### DIFF
--- a/src/utils/generatePropsFromAttributes.js
+++ b/src/utils/generatePropsFromAttributes.js
@@ -10,7 +10,7 @@ import inlineStyleToObject from './inlineStyleToObject';
 export default function generatePropsFromAttributes(attributes, key) {
 
   // generate props
-  const props = Object.assign({}, htmlAttributesToReact(attributes), { key });
+  const props = Object.assign({ key }, htmlAttributesToReact(attributes));
 
   // if there is an inline/string style prop then convert it to a React style object
   // otherwise, it is invalid and omitted


### PR DESCRIPTION
I kept making nice and unique keys and then wondered why they never got used.