### PR TITLE
Fix style values containing upper-case characters

### DIFF
--- a/src/utils/inlineStyleToObject.js
+++ b/src/utils/inlineStyleToObject.js
@@ -20,7 +20,7 @@ export default function InlineStyleToObject(inlineStyle = '') {
         let [property, value] = stylePropertyValue
           .split(/^([^:]+):/)
           .filter((val, i) => i > 0)
-          .map(item => item.trim().toLowerCase());
+          .map(item => item.trim());
 
         // if there is no value (i.e. no : in the style) then ignore it
         if (value === undefined) {
@@ -33,6 +33,7 @@ export default function InlineStyleToObject(inlineStyle = '') {
         // e.g. -ms-style-property = msStyleProperty
         //      -webkit-style-property = WebkitStyleProperty
         property = property
+          .toLowerCase()
           .replace(/^-ms-/, 'ms-')
           .replace(/-(.)/g, (_, character) => character.toUpperCase());
 

--- a/test/unit/utils/inlineStyleToObject.spec.js
+++ b/test/unit/utils/inlineStyleToObject.spec.js
@@ -42,4 +42,12 @@ describe('Testing `utils/inlineStyleToObject', () => {
     expect(inlineStyleToObject(inlineStyle)).toEqual(expectedStyleObject);
   });
 
+  it('should parse style values containing upper-case characters correctly', () => {
+    const inlineStyle = 'background:url(https://test.com/IMAGE.png);';
+    const expectedStyleObject = {
+      background: 'url(https://test.com/IMAGE.png)',
+    };
+    expect(inlineStyleToObject(inlineStyle)).toEqual(expectedStyleObject);
+  });
+
 });


### PR DESCRIPTION
`inlineStyleToObject('background:url(https://test.com/IMAGE.png)')` returns:
before: `{ background: 'url(https://test.com/image.png)' }`
after: `{ background: 'url(https://test.com/IMAGE.png)' }`