### PR TITLE
CSS custom properties are processed incorrectly

### DIFF
--- a/src/utils/inlineStyleToObject.js
+++ b/src/utils/inlineStyleToObject.js
@@ -34,7 +34,7 @@ export default function InlineStyleToObject(inlineStyle = '') {
         //      -webkit-style-property = WebkitStyleProperty
         property = property
           .replace(/^-ms-/, 'ms-')
-          .replace(/-(.)/g, (_, character) => character.toUpperCase());
+          .replace(/-(.)/g, (_, character) => character);
 
         // add the new style property and value to the style object
         styleObject[property] = value;

--- a/src/utils/inlineStyleToObject.js
+++ b/src/utils/inlineStyleToObject.js
@@ -4,6 +4,8 @@
  * @param {String} inlineStyle='' The inline style to convert
  * @returns {Object} The converted style
  */
+
+
 export default function InlineStyleToObject(inlineStyle = '') {
 
   // just return empty object if the inlineStyle is empty
@@ -32,9 +34,11 @@ export default function InlineStyleToObject(inlineStyle = '') {
         // additionally don't uppercase any -ms- prefix
         // e.g. -ms-style-property = msStyleProperty
         //      -webkit-style-property = WebkitStyleProperty
-        property = property
-          .replace(/^-ms-/, 'ms-')
-          .replace(/-(.)/g, (_, character) => character.toUpperCase());
+        if (property.slice(0, 2) !== '--') {      // It doesn't change the custom CSS properties
+          property = property
+            .replace(/^-ms-/, 'ms-')
+            .replace(/-(.)/g, (_, character) => character.toUpperCase());
+        }
 
         // add the new style property and value to the style object
         styleObject[property] = value;

--- a/src/utils/inlineStyleToObject.js
+++ b/src/utils/inlineStyleToObject.js
@@ -34,7 +34,7 @@ export default function InlineStyleToObject(inlineStyle = '') {
         //      -webkit-style-property = WebkitStyleProperty
         property = property
           .replace(/^-ms-/, 'ms-')
-          .replace(/-(.)/g, (_, character) => character);
+          .replace(/-(.)/g, (_, character) => character.toUpperCase());
 
         // add the new style property and value to the style object
         styleObject[property] = value;


### PR DESCRIPTION
Changes were made in https://github.com/abhisheksharmacodes/react-html-parser/blob/master/src/utils/inlineStyleToObject.js file to better process custom CSS properties. 

Before changes:
"--css-properties" was processed as "-Css-Properties" resulting in errors.

After changes:
"--css-properties" is processed as it is to avoid errors and inbuilt properties are converted as intended.